### PR TITLE
Upgrade BxSlider v4.0.0 to BxSlider v4.1.2

### DIFF
--- a/css/jquery.bxslider.css
+++ b/css/jquery.bxslider.css
@@ -1,8 +1,8 @@
 /**
- * BxSlider v4.0 - Fully loaded, responsive content slider
+ * BxSlider v4.1.2 - Fully loaded, responsive content slider
  * http://bxslider.com
  *
- * Written by: Steven Wanderski, 2012
+ * Written by: Steven Wanderski, 2014
  * http://stevenwanderski.com
  * (while drinking Belgian ales and listening to jazz)
  *
@@ -33,9 +33,16 @@
 	-moz-box-shadow: 0 0 5px #ccc;
 	-webkit-box-shadow: 0 0 5px #ccc;
 	box-shadow: 0 0 5px #ccc;
-	border: solid #fff 5px;
+	border:  5px solid #fff;
 	left: -5px;
 	background: #fff;
+
+	/*fix other elements on the page moving (on Chrome)*/
+	-webkit-transform: translatez(0);
+	-moz-transform: translatez(0);
+    	-ms-transform: translatez(0);
+    	-o-transform: translatez(0);
+    	transform: translatez(0);
 }
 
 .bx-wrapper .bx-pager,


### PR DESCRIPTION
Changelog

Version 4.1.2
-Added bower.json configuration file. Manage bxSlider as a dependency using bower.

Version 4.1.1
-Removed imagesLoaded library and added iframe preloading support
-Added responsive option - setting to false will prevent $(window).resize binding

Version 4.1
-Carousel mode (minSlides / maxSlides) was re-written to be more intuitive.
-SlideWidth now acts as it should (slides respect the width value).
-SlideWidth now properly parsed: accepts string ("600px") or integer (600).
-Slider now only needs to load visible slides (by default) in order to initialize which results in much faster loading. A "preloadImages" setting allows for configuration.