### PR TITLE
changed fennec location 

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,10 +8,10 @@
 
         <link rel="stylesheet" media="screen,projection,tv" href="css/styles.css" />
         <link href="css/jquery.bxslider.css" rel="stylesheet" />
-		
+
 	<!--Tabzilla stylesheet-->
         <link href="http://mozorg.cdn.mozilla.net/media/css/tabzilla-min.css" rel="stylesheet" />
-		
+
 
         <!--[if lte IE 8]>
         <script src="js/libs/html5shiv.js"></script>
@@ -34,10 +34,10 @@
         <script src="js/libs/modernizr.custom.26887.js"></script>
         <script src="js/base/site.js"></script>
         <script src="js/libs/jquery.bxslider.min.js"></script>
-		
+
 	<!-- Remote -->
 	<script src="http://www.mozilla.org/tabzilla/media/js/tabzilla.js"></script>
-		
+
         <script>
          $(document).ready(function () {
              $('.bxslider').bxSlider({maxSlides:1, auto: true});
@@ -92,7 +92,7 @@
                     </a><img
                         class="logo"
                         src="https://mozorg.cdn.mozilla.net/media/img/styleguide/identity/firefox/usage-logo.png"
-                    /><a href="ftp://ftp.mozilla.org/pub/mobile/releases/31.0/android/" target="_blank">
+                    /><a href="https://www.mozilla.org/en-US/firefox/android/" target="_blank">
                         Firefox for Android
                         <small>Download in your language</small>
                     </a>
@@ -187,7 +187,7 @@
                         <li><a href="http://www.facebook.com/mozillaindia">Facebook</a></li>
                         <li><a href="http://flickr.com/photos/mozillaindia/">Flickr</a></li>
                         <li><a href="http://youtube.com/user/MozillaIndia">Youtube</a></li>
-                        <li><a href="https://plus.google.com/103052563100386898416" rel="publisher">Google+</a></li> 
+                        <li><a href="https://plus.google.com/103052563100386898416" rel="publisher">Google+</a></li>
                     </ul>
 
                 </div>
@@ -202,7 +202,7 @@
 
         <script src="js/base/nav-main-resp.js"></script>
         <script src="js/mozorg-resp-min.js"></script>
-		
+
         <script>
          window.scrollback = {
              streams: ['mozilla-india'],


### PR DESCRIPTION
As discussed in the issue(https://github.com/MozillaIndia/homepage/issues/61), location of fennec is changed from ftp to https://www.mozilla.org/en-US/firefox/android/