### PR TITLE
changed fennec location

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,7 +92,7 @@
                     </a><img
                         class="logo"
                         src="https://mozorg.cdn.mozilla.net/media/img/styleguide/identity/firefox/usage-logo.png"
-                    /><a href="ftp://ftp.mozilla.org/pub/mobile/releases/31.0/android/" target="_blank">
+                    /><a href="https://www.mozilla.org/firefox/android/" target="_blank">
                         Firefox for Android
                         <small>Download in your language</small>
                     </a>


### PR DESCRIPTION
As discussed in the issue(https://github.com/MozillaIndia/homepage/issues/61), location of Fennec is changed from ftp to https://www.mozilla.org/firefox/android/