### PR TITLE
Fix bug #65: Uneven spacing inside carousel

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,16 +73,14 @@
                     <h2>Unity in the midst of diversity</h2>
                 </hgroup>
 
-                <div id="main-content">
-
-                    <div id="about" class="container divider">
-                        <ul class="bxslider">
-                            <li><img src="img/promo/promo_1.jpg" /></li>
-                            <li><img src="img/promo/promo_2.jpg" /></li>
-                            <li><img src="img/promo/promo_3.jpg" /></li>
-                            <li><img src="img/promo/promo_4.jpg" /></li>
-                        </ul>
-                    </div>
+                <!-- bxslider -->
+                <div class="container divider">
+                    <ul class="bxslider">
+                        <li><img src="img/promo/promo_1.jpg" /></li>
+                        <li><img src="img/promo/promo_2.jpg" /></li>
+                        <li><img src="img/promo/promo_3.jpg" /></li>
+                        <li><img src="img/promo/promo_4.jpg" /></li>
+                    </ul>
                 </div>
 
                 <div id="download">

--- a/less/mozin/mozin.less
+++ b/less/mozin/mozin.less
@@ -2,6 +2,7 @@
 
 #download {
     width: 100%;
+    margin-top: 4rem;
     margin-bottom: 2rem;
     padding-bottom: 4rem;
     border-bottom: 1px solid #ddd;
@@ -77,6 +78,11 @@
 
 }
 
+/* bxslider */
+ul.bxslider li {
+    margin: 0px;
+}
+
 /* Mobile Layout: 320px */
 @media only screen and (max-width: @breakTablet) {
 
@@ -98,14 +104,6 @@
             font-size: 20px;
             letter-spacing: normal;
             margin-top: 7px;
-        }
-    }
-
-    #main-content {
-
-        #about {
-            margin-bottom: 0;
-            padding-bottom: 0;
         }
     }
 


### PR DESCRIPTION
I have removed the duplicate id (`main-content`) that covers the bxslider. The other `main-content` id had many defined attributes, so I left it as it was. The id `about` was unnecessary. It did not define the contents inside it and did not have any properties.