### PR TITLE
Fix bug #70: Responsive firefox logo

### DIFF
--- a/less/mozin/mozin.less
+++ b/less/mozin/mozin.less
@@ -107,6 +107,15 @@ ul.bxslider li {
         }
     }
 
+    #download {
+
+        .logo {
+            width: 80px;
+            margin: 20px -40px;
+            position: absolute;
+        }
+    }
+
 }
 /* }}} Mobile Layout */
 /* {{{ Tablet  Layout: 768px */


### PR DESCRIPTION
For devices with **<480px** width, the firefox logo fits inside the download box.